### PR TITLE
chore: inject webpack blue and neutral color palette

### DIFF
--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,0 +1,10 @@
+import DefaultLayout from '@node-core/doc-kit/src/generators/web/ui/components/Layout/index.jsx';
+import '../styles/theme.css';
+
+export default function Layout(props) {
+  return (
+    <>
+      <DefaultLayout {...props} />
+    </>
+  );
+}

--- a/doc-kit.config.mjs
+++ b/doc-kit.config.mjs
@@ -40,6 +40,7 @@ export default {
     imports: {
       '#theme/Sidebar': join(ROOT, 'components/SideBar.jsx'),
       '#theme/site': join(ROOT, DOCS_DIR, 'site.json'),
+      '#theme/Layout': join(ROOT, 'components/Layout.jsx'),
     },
   },
 };

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,27 @@
+:root {
+  /* Brand — Webpack Cube Blue (Primary) */
+  --color-green-50: #f0f8fe;
+  --color-green-100: #e0effd;
+  --color-green-200: #b9def9;
+  --color-green-300: #8ed6fb;
+  --color-green-400: #4ba8de;
+  --color-green-500: #2b8fcf;
+  --color-green-600: #1c78c0;
+  --color-green-700: #175e96;
+  --color-green-800: #134c79;
+  --color-green-900: #0f3c61;
+  --color-green-950: #0a2c47;
+
+  /* Neutrals — Surfaces, Type, Borders */
+  --color-neutral-50: #fbfcfd;
+  --color-neutral-100: #f6f7f9;
+  --color-neutral-200: #e9edf0;
+  --color-neutral-300: #d9e1e4;
+  --color-neutral-400: #cbd4d9;
+  --color-neutral-500: #b1bcc2;
+  --color-neutral-600: #929fa5;
+  --color-neutral-700: #6e7b83;
+  --color-neutral-800: #556066;
+  --color-neutral-900: #2c3437;
+  --color-neutral-950: #0d121c;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
Closes: #93 

**Summary**
This PR describes the theme colors for webpack

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

For now, its looking like this :
<img width="1074" height="965" alt="image" src="https://github.com/user-attachments/assets/b03f3e51-a712-431a-9db0-9933c7824752" />

<img width="1074" height="965" alt="Screenshot from 2026-05-26 12-17-22" src="https://github.com/user-attachments/assets/102b2679-9bf6-49c0-b912-790d01e70bd4" />



**What kind of change does this PR introduce?**
chore

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**
no

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**
no

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**
n/a

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**
used ai to map variable names described in nodejs doc repo with the webpack branding color values.

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->