### PR TITLE
fix(theme): replace 'Call Signature' with the real signature in functions overload

### DIFF
--- a/plugins/shared/titles.mjs
+++ b/plugins/shared/titles.mjs
@@ -107,13 +107,23 @@ export const getMemberPrefix = model => {
   return prefix ? `${prefix}: ` : '';
 };
 
-export const getMemberTitle = (model, options) => {
+export const getMemberTitle = (
+  model,
+  options,
+  specificSignature = null,
+  omitParams = false
+) => {
   const prefix = getMemberPrefix(model);
-  const params = model.parameters ?? callableSignatures(model)[0]?.parameters;
   const name = escapeCode(memberName(model, options));
 
-  if (params) {
-    return `${prefix}\`${escapeCode(signatureExpression(model, params, name))}\``;
+  if (!omitParams) {
+    const params =
+      specificSignature?.parameters ??
+      model.parameters ??
+      callableSignatures(model)[0]?.parameters;
+    if (params) {
+      return `${prefix}\`${escapeCode(signatureExpression(model, params, name))}\``;
+    }
   }
 
   return `${prefix}\`${name}\``;

--- a/plugins/shared/titles.mjs
+++ b/plugins/shared/titles.mjs
@@ -107,23 +107,16 @@ export const getMemberPrefix = model => {
   return prefix ? `${prefix}: ` : '';
 };
 
-export const getMemberTitle = (
-  model,
-  options,
-  specificSignature = null,
-  omitParams = false
-) => {
+export const getMemberTitle = (model, options, specificSignature = null) => {
   const prefix = getMemberPrefix(model);
   const name = escapeCode(memberName(model, options));
 
-  if (!omitParams) {
-    const params =
-      specificSignature?.parameters ??
-      model.parameters ??
-      callableSignatures(model)[0]?.parameters;
-    if (params) {
-      return `${prefix}\`${escapeCode(signatureExpression(model, params, name))}\``;
-    }
+  const params =
+    specificSignature?.parameters ??
+    model.parameters ??
+    callableSignatures(model)[0]?.parameters;
+  if (params) {
+    return `${prefix}\`${escapeCode(signatureExpression(model, params, name))}\``;
   }
 
   return `${prefix}\`${name}\``;

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -96,7 +96,7 @@ export default ctx => {
         if (multipleSignatures) {
           md.push(
             heading(
-              options.headingLevel + 1,
+              options.headingLevel,
               getMemberTitle(
                 model,
                 { local: isTypePage(ctx.page.model) },
@@ -108,8 +108,8 @@ export default ctx => {
         md.push(
           ctx.partials.signature(signature, {
             headingLevel: multipleSignatures
-              ? options.headingLevel + 2
-              : options.headingLevel + 1,
+              ? options.headingLevel + 1
+              : options.headingLevel,
             nested: options.nested,
             multipleSignatures: false,
           })
@@ -226,6 +226,31 @@ export default ctx => {
       });
     },
 
+    memberContainer(model, options) {
+      const md = [];
+
+      const isOverloadedMethod =
+        model.signatures &&
+        model.signatures.length > 1 &&
+        [ReflectionKind.Function, ReflectionKind.Method].includes(model.kind);
+
+      if (
+        !isOverloadedMethod &&
+        !ctx.router.hasOwnDocument(model) &&
+        model.kind !== ReflectionKind.Constructor
+      ) {
+        md.push(heading(options.headingLevel, ctx.partials.memberTitle(model)));
+      }
+
+      md.push(
+        ctx.partials.member(model, {
+          headingLevel: options.headingLevel,
+          nested: options.nested,
+        })
+      );
+      return md.join('\n\n');
+    },
+
     memberWithGroups(model, options) {
       const md = [];
       const stability = ctx.helpers.stabilityBlockquote(model.comment);
@@ -321,7 +346,7 @@ export default ctx => {
               headingLevel: multipleSignatures
                 ? options.headingLevel + 1
                 : options.headingLevel,
-              multipleSignatures: false,
+              multipleSignatures,
             })
           );
         });
@@ -359,12 +384,7 @@ export default ctx => {
     },
 
     memberTitle: model =>
-      getMemberTitle(
-        model,
-        { local: isTypePage(ctx.page.model) },
-        null,
-        model.signatures?.length > 1
-      ),
+      getMemberTitle(model, { local: isTypePage(ctx.page.model) }),
     parametersList(parameters) {
       const flatList = [];
 

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -73,6 +73,51 @@ export default ctx => {
         .join('\n');
     },
 
+    signatures(model, options) {
+      const md = [];
+      const multipleSignatures =
+        model.signatures && model.signatures?.length > 1;
+
+      if (model.comment && multipleSignatures) {
+        md.push(
+          ctx.partials.comment(model.comment, {
+            headingLevel: options.headingLevel + 1,
+          })
+        );
+      }
+      if (multipleSignatures && model.documents) {
+        md.push(
+          ctx.partials.documents(model, {
+            headingLevel: options.headingLevel + 1,
+          })
+        );
+      }
+      model.signatures?.forEach(signature => {
+        if (multipleSignatures) {
+          md.push(
+            heading(
+              options.headingLevel + 1,
+              getMemberTitle(
+                model,
+                { local: isTypePage(ctx.page.model) },
+                signature
+              )
+            )
+          );
+        }
+        md.push(
+          ctx.partials.signature(signature, {
+            headingLevel: multipleSignatures
+              ? options.headingLevel + 2
+              : options.headingLevel + 1,
+            nested: options.nested,
+            multipleSignatures: false,
+          })
+        );
+      });
+      return md.join('\n\n');
+    },
+
     declaration(model, options) {
       const opts = { headingLevel: 2, nested: false, ...options };
       const signatures = callableSignatures(model);
@@ -260,14 +305,23 @@ export default ctx => {
         const multipleSignatures = model.signatures.length > 1;
         model.signatures.forEach(signature => {
           if (multipleSignatures) {
-            md.push(heading(options.headingLevel, i18n.kind_call_signature()));
+            md.push(
+              heading(
+                options.headingLevel,
+                getMemberTitle(
+                  model,
+                  { local: isTypePage(ctx.page.model) },
+                  signature
+                )
+              )
+            );
           }
           md.push(
             ctx.partials.signature(signature, {
               headingLevel: multipleSignatures
                 ? options.headingLevel + 1
                 : options.headingLevel,
-              multipleSignatures,
+              multipleSignatures: false,
             })
           );
         });
@@ -305,7 +359,12 @@ export default ctx => {
     },
 
     memberTitle: model =>
-      getMemberTitle(model, { local: isTypePage(ctx.page.model) }),
+      getMemberTitle(
+        model,
+        { local: isTypePage(ctx.page.model) },
+        null,
+        model.signatures?.length > 1
+      ),
     parametersList(parameters) {
       const flatList = [];
 

--- a/plugins/theme/partials/index.mjs
+++ b/plugins/theme/partials/index.mjs
@@ -78,20 +78,6 @@ export default ctx => {
       const multipleSignatures =
         model.signatures && model.signatures?.length > 1;
 
-      if (model.comment && multipleSignatures) {
-        md.push(
-          ctx.partials.comment(model.comment, {
-            headingLevel: options.headingLevel + 1,
-          })
-        );
-      }
-      if (multipleSignatures && model.documents) {
-        md.push(
-          ctx.partials.documents(model, {
-            headingLevel: options.headingLevel + 1,
-          })
-        );
-      }
       model.signatures?.forEach(signature => {
         if (multipleSignatures) {
           md.push(

--- a/tests/theme/theme.test.mjs.snapshot
+++ b/tests/theme/theme.test.mjs.snapshot
@@ -119,22 +119,20 @@ Class demonstrating overload signatures.
 
 ### \`overloadMethod(name, count)\`
 
-#### Call Signature
-
 * \`name\` {string} A simple string parameter
 * \`count\` {number} A simple number parameter
 * Returns: {void} 
 
 First overload signature.
 
-#### Call Signature
+### \`overloadMethod(isEnabled)\`
 
 * \`isEnabled\` {boolean} A simple boolean parameter
 * Returns: {string} 
 
 Second overload signature.
 
-#### Call Signature
+### \`overloadMethod(id, isEnabled)\`
 
 * \`id\` {number} A simple string parameter
 * \`isEnabled\` {boolean} A simple boolean parameter


### PR DESCRIPTION
## Summary

This PR shows the real signature of standalone functions and classes' methods overloads instead of `Call Signature`, removes the main method heading if the function is overloaded to prevent duplicate titles, and removes the shared general comment from rendering as it hasn't parent after we removed the main header above the overloads.

### Before:
<img width="875" height="353" alt="image" src="https://github.com/user-attachments/assets/eaca44f6-1aba-48d5-a857-5d0efff345ef" />

### After:
<img width="864" height="316" alt="image" src="https://github.com/user-attachments/assets/0cc67b02-5b51-4e69-a92d-5160cfc9b4a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved API documentation for overloaded methods by displaying each overload with its specific method signature.
  - Added clearer headings for callable members while avoiding duplicate headings for constructors and routed members.
  - Preserved existing parameter, return, and description details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->