### PR TITLE
fix: authenticate GitHub API requests and remove outdated release TODOs

### DIFF
--- a/pages/blog/posts/2020-10-10-webpack-5-release.md
+++ b/pages/blog/posts/2020-10-10-webpack-5-release.md
@@ -1066,7 +1066,7 @@ That means the following information about modules has been moved:
 
 - Module connections -> ModuleGraph
 - Module issuer -> ModuleGraph
-- Module optimization bailout -> ModuleGraph (TODO: check if it should ChunkGraph instead)
+- Module optimization bailout -> ModuleGraph
 - Module usedExports -> ModuleGraph
 - Module providedExports -> ModuleGraph
 - Module pre order index -> ModuleGraph
@@ -1257,8 +1257,8 @@ These dependencies are cheaper to process and webpack uses them when possible
 - `Chunk.getChunkModuleMaps` is deprecated
 - `Chunk.hasModuleInGraph` is deprecated
 - `Chunk.updateHash` signature changed
-- `Chunk.getChildIdsByOrders` signature changed (TODO: consider moving to `ChunkGraph`)
-- `Chunk.getChildIdsByOrdersMap` signature changed (TODO: consider moving to `ChunkGraph`)
+- `Chunk.getChildIdsByOrders` signature changed
+- `Chunk.getChildIdsByOrdersMap` signature changed
 - `Chunk.getChunkModuleMaps` removed
 - `Chunk.setModules` removed
 - deprecated Chunk methods removed

--- a/scripts/markdown/readmes.mjs
+++ b/scripts/markdown/readmes.mjs
@@ -15,6 +15,9 @@ const discoverRepos = async () => {
 
   while (url) {
     const res = await fetchWithAuth(url);
+    if (!res.ok) {
+      throw new Error(`GitHub API returned ${res.status}: ${await res.text()}`);
+    }
 
     for (const repo of await res.json()) {
       if (repo.archived) continue;

--- a/scripts/utils/fetch.mjs
+++ b/scripts/utils/fetch.mjs
@@ -51,7 +51,7 @@ export const fetchWithAuth = (url, fetchOptions = {}, retryOptions) =>
       ...fetchOptions,
       headers: {
         ...fetchOptions?.headers,
-        githubHeaders,
+        ...githubHeaders,
       },
     },
     retryOptions


### PR DESCRIPTION
**Summary**

This PR removes outdated `(TODO: ...)` notes in the Webpack 5 release blog post, and spreads the `githubHeaders` object to attach GitHub authentication headers, preventing API rate limiting and CI script failures.

**Verification on docs:**

I double-checked the Webpack 5 source code:

- `optimizationBailout` is in `ModuleGraph` (not `ChunkGraph`).
- `getChildIdsByOrders` and `getChildIdsByOrdersMap` are remain in the `Chunk`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed outdated TODO notes from descriptions of several Webpack 5 API and optimization changes.

* **Bug Fixes**
  * Improved error reporting when repository discovery requests fail.
  * Preserved existing request headers while adding GitHub authentication and API headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->