### PR TITLE
fix(scripts): normalize npm pack json output to support npm v12+

### DIFF
--- a/scripts/prepare/index.mjs
+++ b/scripts/prepare/index.mjs
@@ -14,13 +14,14 @@ const execOptions = {
 const fetchWebpack = version => {
   console.log(`Fetching webpack ${version}`);
 
-  const [{ filename }] = JSON.parse(
+  const result = JSON.parse(
     execFileSync(
       'npm',
       ['pack', `webpack@${version}`, '--json', '--pack-destination', CACHE_DIR],
       execOptions
     )
   );
+  const { filename } = Array.isArray(result) ? result[0] : result;
   const archive = join(CACHE_DIR, filename);
   const destination = join(CACHE_DIR, version);
 


### PR DESCRIPTION
**Summary**

This PR normalizes npm pack json output. In newer versions of `npm`  v12+, the output structure of the `npm pack --json` command changed from an array of objects to a flat object. This broke our JSON parser which strictly expected an array via destructuring. So this PR lets us support both ways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package preparation compatibility by supporting both array and single-object results from package metadata commands.
  * Preserved existing package extraction and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->