### PR TITLE
fix(scripts): add missing target flag for llms-txt generator

### DIFF
--- a/scripts/html/index.mjs
+++ b/scripts/html/index.mjs
@@ -17,10 +17,12 @@ const runDocKit = version =>
       'orama-db',
       '-t',
       'sitemap',
+      '-t',
       'llms-txt',
       '--config-file',
       './scripts/html/doc-kit.config.mjs',
     ],
+
     {
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary

In `scripts/html/index.mjs`, the `web`, `orama-db`, and `sitemap` targets use the `-t` flag explicitly.

`llms-txt` was missing its own `-t` flag. This change adds it for consistency:

```js
'-t', 'sitemap', '-t', 'llms-txt',
```

The CLI was handling `llms-txt` correctly, But by this change it just makes the arguments consistent and easier to maintain for future target additions .

## What kind of change does this PR introduce?

* Fix / Code cleanup
* Makes the CLI target arguments consistent

## Did you add tests for your changes?

No new tests were added because this is a small CLI argument formatting change.

The following checks were run successfully:

* `npm run lint`
* `npm run format:check`
* `npm test`
* `coderabbit review --agent` — 0 findings

## Does this PR introduce a breaking change?

No.

## Documentation

No documentation changes are needed because this is an internal build script change.

## Use of AI

AI was used to understand behaviour of inconsistent flag in `scripts/html/index.mjs`  only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation generation now supports the `orama-db` target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->