### PR TITLE
fix(release): Corrected create-post paths

### DIFF
--- a/scripts/release/create-post.mjs
+++ b/scripts/release/create-post.mjs
@@ -4,7 +4,7 @@ import { parseArgs } from 'node:util';
 import Handlebars from 'handlebars';
 import matter from 'gray-matter';
 
-import { fetchWithAuth } from '../../utils/fetch.mjs';
+import { fetchWithAuth } from '../utils/fetch.mjs';
 
 const { values } = parseArgs({
   options: {
@@ -87,7 +87,7 @@ const changes = changesets.map(parseChangeset);
 const post = await renderReleaseNotes(version, changes, date);
 writeFile(
   new URL(
-    import.meta.resolve(`../../../pages/blog/${date}-webpack-${version}.md`)
+    import.meta.resolve(`../../pages/blog/posts/${date}-webpack-${version}.md`)
   ),
   post
 );


### PR DESCRIPTION
**Summary**

>This fixes two incorrect paths in scripts/release/create-post.mjs.

>The script could not import the shared fetch utility because the relative path pointed to a non-existent location. Its output path also pointed outside the repository, so generated blog posts could not be written.

>The paths now point to the correct files and pages/blog/posts/ directory.

**What kind of change does this PR introduce?**
fix

**Did you add tests for your changes?**
Affected modules  checked with Node.js syntax validation, ESLint, and VS Code diagnostics. The old and corrected import paths  tested directly.

**Does this PR introduce a breaking change?**
No. It only fixes  release script paths & does not change any other files.

**Use of AI**
No

Fixes: #263 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected release-post generation so new release announcements are published to the intended blog location.
  - Improved the release publishing workflow’s authenticated content retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->